### PR TITLE
adding gitlab-api required dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
   <properties>
     <revision>2.35-5</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.249.1</jenkins.version>
+    <jenkins.version>2.263.1</jenkins.version>
     <java.level>8</java.level>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
@@ -53,6 +53,11 @@
   </dependencyManagement>
 
   <dependencies>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>javax-activation-api</artifactId>
+      <version>1.2.0-2</version>
+    </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.connectors</groupId>
       <artifactId>jersey-apache-connector</artifactId>
@@ -94,6 +99,40 @@
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-sse</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+      <exclusions>
+        <!-- Provided by jackson2-api plugin -->
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.module</groupId>
+          <artifactId>jackson-module-jaxb-annotations</artifactId>
+        </exclusion>
+        <!-- Provided by javax-activation-api plugin -->
+        <exclusion>
+          <groupId>jakarta.activation</groupId>
+          <artifactId>jakarta.activation-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
+      <version>2.13.1-999999-SNAPSHOT</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -94,24 +94,12 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
-      <artifactId>jersey-media-multipart</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.media</groupId>
-      <artifactId>jersey-media-sse</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
       <exclusions>
         <!-- Provided by jackson2-api plugin -->
         <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-core</artifactId>
         </exclusion>
         <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>
@@ -129,15 +117,23 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>jackson2-api</artifactId>
-      <version>2.13.1-999999-SNAPSHOT</version>
-      <optional>true</optional>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-multipart</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-sse</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
       <version>4.5.13-1.0</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
+      <version>2.13.1-257.vb_254f61c3a_2b_</version> <!-- TODO https://github.com/jenkinsci/jackson2-api-plugin/pull/122 -->
       <optional>true</optional>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
-      <version>2.13.1-257.vb_254f61c3a_2b_</version> <!-- TODO https://github.com/jenkinsci/jackson2-api-plugin/pull/122 -->
+      <version>2.13.2-264.v22b_4f3616f0c</version> <!-- TODO https://github.com/jenkinsci/jackson2-api-plugin/pull/122 -->
       <optional>true</optional>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
-      <version>2.13.2-264.v22b_4f3616f0c</version> <!-- TODO https://github.com/jenkinsci/jackson2-api-plugin/pull/122 -->
+      <version>2.13.2.20220328-273.v11d70a_b_a_1a_52</version>
       <optional>true</optional>
     </dependency>
   </dependencies>

--- a/src/test/java/org/glassfish/jersey/jackson/JacksonFeatureTest.java
+++ b/src/test/java/org/glassfish/jersey/jackson/JacksonFeatureTest.java
@@ -1,7 +1,10 @@
 package org.glassfish.jersey.jackson;
 
+import org.glassfish.jersey.client.JerseyClient;
+import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.RealJenkinsRule;
 
 public class JacksonFeatureTest {
@@ -10,6 +13,13 @@ public class JacksonFeatureTest {
 
     @Test
     public void smokes() throws Throwable {
-        rr.then(j -> new JacksonFeature());
+        rr.then(JacksonFeatureTest::_smokes);
+    }
+
+    private static void _smokes(JenkinsRule r) {
+        JerseyClientBuilder builder = new JerseyClientBuilder();
+        builder.register(JacksonFeature.class);
+        JerseyClient client = builder.build();
+        client.preInitialize();
     }
 }

--- a/src/test/java/org/glassfish/jersey/jackson/JacksonFeatureTest.java
+++ b/src/test/java/org/glassfish/jersey/jackson/JacksonFeatureTest.java
@@ -1,0 +1,15 @@
+package org.glassfish.jersey.jackson;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.RealJenkinsRule;
+
+public class JacksonFeatureTest {
+
+    @Rule public RealJenkinsRule rr = new RealJenkinsRule();
+
+    @Test
+    public void smokes() throws Throwable {
+        rr.then(j -> new JacksonFeature());
+    }
+}


### PR DESCRIPTION
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Adding `jersey-media-json-jackson` dependency required by the `gitlab-api` plugin
https://github.com/jenkinsci/gitlab-api-plugin/pull/7


Also adding a dependency on `jackson2-api` plugin, to prevent a circular dependency error, `jackson2-api` plugin needs to be updated to remove its dependency on `jersey2-api`. `gitlab-plugin` needs to use `jersey-media-json-jackson` instead of `jackson-jaxrs-json-provider`.

A release of the 3 plugins with the following PRs will need to be coordinated:

- https://github.com/jenkinsci/jersey2-api-plugin/pull/9
- https://github.com/jenkinsci/jackson2-api-plugin/pull/122
- https://github.com/jenkinsci/gitlab-plugin/pull/1255

