### PR TITLE
Add `jersey-media-multipart`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,10 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-multipart</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-sse</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
A safe subset of #9 that adds `jersey-media-multipart` but not `jersey-media-json-jackson` (which causes a circular dependency problem with the Jackson 2 API plugin). CC @dcendents @jetersen @mymarche