### PR TITLE
Remove `jakarta.activation-api-1.2.2.jar` and `jakarta.xml.bind-api-2.3.3.jar` from JPI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,13 @@
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jettison</artifactId>
+      <exclusions>
+        <!-- Provided by jaxb plugin -->
+        <exclusion>
+          <groupId>jakarta.xml.bind</groupId>
+          <artifactId>jakarta.xml.bind-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>


### PR DESCRIPTION
These were inadvertently added in #24 and are unneeded because of our dependency on the `javax-activation-api` and `jaxb` plugins.