### PR TITLE
Revert Jersey 2.39 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   </scm>
 
   <properties>
-    <revision>2.39-2</revision>
+    <revision>2.38-2</revision>
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.361.4</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
@@ -44,7 +44,7 @@
       <dependency>
         <groupId>org.glassfish.jersey</groupId>
         <artifactId>jersey-bom</artifactId>
-        <version>2.39</version>
+        <version>2.38</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
This seems to be causing users a lot of pain in https://github.com/jenkinsci/gitlab-plugin/issues/1419, so let's revert the upgrade and suspend the problematic version from distribution in https://github.com/jenkins-infra/update-center2/pull/688.