### PR TITLE
Add RESTEasy tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,48 @@
       <version>2.14.2-319.v37853346a_229</version>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+      <version>3.15.6.Final</version>
+      <scope>test</scope>
+      <exclusions>
+        <!-- Provided by Jenkins core -->
+        <exclusion>
+          <groupId>com.github.stephenc.jcip</groupId>
+          <artifactId>jcip-annotations</artifactId>
+        </exclusion>
+        <!-- Provided by javax-activation-api plugin -->
+        <exclusion>
+          <groupId>com.sun.activation</groupId>
+          <artifactId>jakarta.activation</artifactId>
+        </exclusion>
+        <!-- Provided by Jenkins core -->
+        <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+        </exclusion>
+        <!-- Provided by javax-activation-api plugin -->
+        <exclusion>
+          <groupId>jakarta.activation</groupId>
+          <artifactId>jakarta.activation-api</artifactId>
+        </exclusion>
+        <!-- Provided by jaxb plugin -->
+        <exclusion>
+          <groupId>jakarta.xml.bind</groupId>
+          <artifactId>jakarta.xml.bind-api</artifactId>
+        </exclusion>
+        <!-- Provided by apache-httpcomponents-client-4-api plugin -->
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/test/java/org/glassfish/jersey/Employee.java
+++ b/src/test/java/org/glassfish/jersey/Employee.java
@@ -1,0 +1,33 @@
+package org.glassfish.jersey;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+public class Employee {
+
+    private int id;
+    private String firstName;
+
+    public Employee() {}
+
+    public Employee(int id, String firstName) {
+        this.id = id;
+        this.firstName = firstName;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+}

--- a/src/test/java/org/glassfish/jersey/JerseyResource.java
+++ b/src/test/java/org/glassfish/jersey/JerseyResource.java
@@ -1,0 +1,48 @@
+package org.glassfish.jersey;
+
+import hudson.model.UnprotectedRootAction;
+import java.io.IOException;
+import java.net.URL;
+import javax.servlet.ServletException;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+
+public class JerseyResource implements UnprotectedRootAction {
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    @Override
+    public String getUrlName() {
+        return "jersey";
+    }
+
+    public HttpResponse doEmployee(@QueryParameter String q) {
+        String contentType;
+        URL url;
+        if ("json".equals(q)) {
+            contentType = "application/json";
+            url = getClass().getResource("1.json");
+        } else {
+            contentType = "text/xml";
+            url = getClass().getResource("1.xml");
+        }
+        return new HttpResponse() {
+            @Override
+            public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node)
+                    throws IOException, ServletException {
+                rsp.setContentType(contentType + ";charset=UTF-8");
+                rsp.serveFile(req, url, 0);
+            }
+        };
+    }
+}

--- a/src/test/java/org/glassfish/jersey/JerseyTest.java
+++ b/src/test/java/org/glassfish/jersey/JerseyTest.java
@@ -2,112 +2,30 @@ package org.glassfish.jersey;
 
 import static org.junit.Assert.assertEquals;
 
-import hudson.model.UnprotectedRootAction;
-import java.io.IOException;
 import java.net.URI;
-import java.net.URL;
-import javax.servlet.ServletException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
-import javax.xml.bind.annotation.XmlRootElement;
 import org.glassfish.jersey.client.ClientConfig;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.TestExtension;
-import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.jvnet.hudson.test.RealJenkinsRule;
 
 public class JerseyTest {
 
-    @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule public RealJenkinsRule rr = new RealJenkinsRule();
 
     @Test
-    public void xml() throws Exception {
-        ClientConfig clientConfig = new ClientConfig();
-        Client client = ClientBuilder.newClient(clientConfig);
-        URI uri = new URI(j.getURL() + "jersey/employee");
-        Employee employee = client.target(uri).request().get(Employee.class);
-        assertEquals("Noah", employee.getFirstName());
+    public void json() throws Throwable {
+        rr.then(JerseyTest::_json);
     }
 
-    @Test
-    public void json() throws Exception {
+    private static void _json(JenkinsRule j) throws Exception {
+        j.jenkins.getActions().add(new JerseyResource());
         ClientConfig clientConfig = new ClientConfig();
         Client client = ClientBuilder.newClient(clientConfig);
         URI uri = new URI(j.getURL() + "jersey/employee?q=json");
         Employee employee = client.target(uri).request().get(Employee.class);
         assertEquals("Noah", employee.getFirstName());
-    }
-
-    @XmlRootElement
-    public static class Employee {
-
-        private int id;
-        private String firstName;
-
-        public Employee() {}
-
-        public Employee(int id, String firstName) {
-            this.id = id;
-            this.firstName = firstName;
-        }
-
-        public int getId() {
-            return id;
-        }
-
-        public void setId(int id) {
-            this.id = id;
-        }
-
-        public String getFirstName() {
-            return firstName;
-        }
-
-        public void setFirstName(String firstName) {
-            this.firstName = firstName;
-        }
-    }
-
-    @TestExtension
-    public static class JerseyResource implements UnprotectedRootAction {
-
-        @Override
-        public String getIconFileName() {
-            return null;
-        }
-
-        @Override
-        public String getDisplayName() {
-            return null;
-        }
-
-        @Override
-        public String getUrlName() {
-            return "jersey";
-        }
-
-        public HttpResponse doEmployee(@QueryParameter String q) {
-            String contentType;
-            URL url;
-            if ("json".equals(q)) {
-                contentType = "application/json";
-                url = getClass().getResource("1.json");
-            } else {
-                contentType = "text/xml";
-                url = getClass().getResource("1.xml");
-            }
-            return new HttpResponse() {
-                @Override
-                public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node)
-                        throws IOException, ServletException {
-                    rsp.setContentType(contentType + ";charset=UTF-8");
-                    rsp.serveFile(req, url, 0);
-                }
-            };
-        }
     }
 }

--- a/src/test/java/org/glassfish/jersey/RestEasyTest.java
+++ b/src/test/java/org/glassfish/jersey/RestEasyTest.java
@@ -1,0 +1,60 @@
+package org.glassfish.jersey;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import org.glassfish.jersey.jackson.JacksonFeature;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+
+public class RestEasyTest {
+
+    @Rule public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void withoutJackson() throws Exception {
+        ResteasyClientBuilder builder = new ResteasyClientBuilder();
+        final ResteasyClient resteasyClient = builder.connectionPoolSize(60).build();
+        final ResteasyWebTarget target = resteasyClient.target(j.getURL() + "jersey");
+        final EmployeeService employeeService = target.proxy(EmployeeService.class);
+        final String employee = employeeService.getAtAsString("json");
+        final String expected = "{\"id\":1,\"firstName\":\"Noah\"}\n";
+        assertEquals(expected, employee);
+    }
+
+    @Test
+    public void withJackson() throws Exception {
+        ResteasyClientBuilder builder = new ResteasyClientBuilder();
+        final ResteasyClient resteasyClient =
+                builder.register(new JacksonFeature()).connectionPoolSize(60).build();
+        final ResteasyWebTarget target = resteasyClient.target(j.getURL() + "jersey");
+        final EmployeeService employeeService = target.proxy(EmployeeService.class);
+        final Employee employee = employeeService.getAt("json");
+        assertEquals(1, employee.getId());
+        assertEquals("Noah", employee.getFirstName());
+    }
+
+    @Path("/employee")
+    public static interface EmployeeService {
+
+        @GET
+        @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+        Employee getAt(@QueryParam("q") String q);
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        String getAtAsString(@QueryParam("q") String q);
+    }
+
+    @TestExtension
+    public static class RestEasyJerseyResource extends JerseyResource {}
+}

--- a/src/test/java/org/glassfish/jersey/RestEasyTest.java
+++ b/src/test/java/org/glassfish/jersey/RestEasyTest.java
@@ -26,8 +26,8 @@ public class RestEasyTest {
         final ResteasyClient resteasyClient = builder.connectionPoolSize(60).build();
         final ResteasyWebTarget target = resteasyClient.target(j.getURL() + "jersey");
         final EmployeeService employeeService = target.proxy(EmployeeService.class);
-        final String employee = employeeService.getAtAsString("json");
-        final String expected = "{\"id\":1,\"firstName\":\"Noah\"}\n";
+        final String employee = employeeService.getAtAsString("json").trim();
+        final String expected = "{\"id\":1,\"firstName\":\"Noah\"}";
         assertEquals(expected, employee);
     }
 


### PR DESCRIPTION
Add tests that would have caught https://github.com/jenkinsci/gitlab-plugin/issues/1419. These tests fail on Jersey 2.39 with the error reported by users in https://github.com/jenkinsci/gitlab-plugin/issues/1419 and pass on Jersey 2.38.